### PR TITLE
Single Rule Bugfixes

### DIFF
--- a/R/pre.R
+++ b/R/pre.R
@@ -787,7 +787,9 @@ pre <- function(formula, data, family = gaussian,
   
   y <- modmat_data$y
   x <- modmat_data$x  
-
+  
+  if (ncol(x) == 1) x <- cbind(0, x)
+  
   if (is.null(cl$penalty.factor)) {
     penalty.factor <- rep(1L, times = ncol(x))
   } 


### PR DESCRIPTION
Hacky fix. I'm adding a constant column of 0s to the model matrix if it has just 1 column so that `cv.glmnet` won't protest. 